### PR TITLE
Import PropTypes from 'prop-types'

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "peerDependencies": {
     "react-native": "*",
-    "react": "*"
+    "react": "*",
+    "prop-types": "*"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import {
   Easing,
   Animated,


### PR DESCRIPTION
PropTypes moved to different place in react 15.x and will be removed from react namespace in 16.x